### PR TITLE
Importing directories

### DIFF
--- a/compiler/preprocess.go
+++ b/compiler/preprocess.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 
 	"github.com/Zac-Garby/radon/ast"
 	"github.com/Zac-Garby/radon/parser"
@@ -422,6 +423,10 @@ func importDir(path string) (ast.Statement, error) {
 	var stmts []ast.Statement
 
 	for _, file := range files {
+		if !strings.HasSuffix(file.Name(), ".rn") {
+			continue
+		}
+
 		fstmt, err := importFile(filepath.Join(path, file.Name()))
 		if err != nil {
 			return nil, err

--- a/compiler/preprocess.go
+++ b/compiler/preprocess.go
@@ -365,6 +365,10 @@ func preprocessStatement(n ast.Statement) (ast.Statement, error) {
 func processImport(node *ast.Import) (ast.Statement, error) {
 	path := filepath.Join(filepath.Dir(node.Tok.Start.Filename), node.Path)
 
+	return importFile(path)
+}
+
+func importFile(path string) (ast.Statement, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		pathErr := err.(*os.PathError)
@@ -377,7 +381,7 @@ func processImport(node *ast.Import) (ast.Statement, error) {
 	}
 
 	var (
-		p    = parser.New(string(content), node.Path)
+		p    = parser.New(string(content), path)
 		prog = p.Parse()
 	)
 

--- a/examples/functions.rn
+++ b/examples/functions.rn
@@ -1,6 +1,3 @@
 print(add(2, 3))
 
-add(x, y) = {
-    g(x, y)
-    g(x, y) = x + y
-}
+add(x, y) = x + y

--- a/examples/import.rn
+++ b/examples/import.rn
@@ -1,4 +1,4 @@
 # demonstrates importing of local files
 
-import 'calc'
-import '../examples/functions'
+import 'calc.rn'
+import '../examples/functions.rn'


### PR DESCRIPTION
You can now import directories as well as files, using the same syntax (`import '<dirname>'). The compiler will detect its a directory and import all the top-level `.rn` files in it.